### PR TITLE
explicitly specify sphinx version

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+Sphinx ~= 2.1
 exhale ~= 0.2
 sphinx_rtd_theme
 m2r


### PR DESCRIPTION
required to get RTD to use a recent sphinx version