### PR TITLE
Fix missing #includes

### DIFF
--- a/include/ear/gain_calculators.hpp
+++ b/include/ear/gain_calculators.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <map>
+#include <memory>
 #include <string>
 #include <vector>
 #include "export.hpp"

--- a/src/bs2051.cpp
+++ b/src/bs2051.cpp
@@ -2,6 +2,7 @@
 
 #include "ear/helpers/assert.hpp"
 #include "ear/metadata.hpp"
+#include <algorithm>
 
 namespace ear {
 


### PR DESCRIPTION
Allows library to be built with VS2019