### PR TITLE
don't add submodules to public include path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,10 +37,11 @@ add_library(ear
 )
 
 target_include_directories(ear
+  PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/submodules/kissfft>
   PUBLIC
   # Headers used from source/build location:
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/submodules> # submodules
     $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>  # config.h / export.h
   # Headers used from installed location:
     $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>

--- a/src/decorrelate.cpp
+++ b/src/decorrelate.cpp
@@ -6,7 +6,7 @@
 #include <complex>
 #include <random>
 #include "ear/layout.hpp"
-#include "kissfft/kissfft.hh"
+#include "kissfft.hh"
 
 const double PI = boost::math::constants::pi<double>();
 

--- a/src/fft_kiss.cpp
+++ b/src/fft_kiss.cpp
@@ -5,7 +5,7 @@
 #include "ear/export.hpp"
 #include "ear/fft.hpp"
 #include "ear/helpers/assert.hpp"
-#include "kissfft/kissfft.hh"
+#include "kissfft.hh"
 
 namespace ear {
 


### PR DESCRIPTION
This meant that when linking against libear as a subproject, the libear
version of catch2 was included on the include path, which causes issues
if catch2 is used in the parent project. In general, private includes
should be marked as such.