### PR TITLE
Allow setting facets

### DIFF
--- a/include/ear/layout.hpp
+++ b/include/ear/layout.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <boost/optional.hpp>
+#include <set>
 #include <string>
 #include <vector>
 #include "common_types.hpp"
@@ -95,4 +96,12 @@ namespace ear {
     boost::optional<Screen> _screen;
   };
 
+  using Facet = std::set<int>;
+  /// Set the facets to be used when triangulating a named layout.
+  ///
+  /// This is used for rendering with custom loudspeaker layouts; see
+  /// tools/create_facets_cpp.py for code to generate these. In general the use
+  /// of this function can result in non-standard behaviour.
+  void EAR_EXPORT registerFacets(const std::string& layoutName,
+                                 std::vector<Facet> facets);
 }  // namespace ear

--- a/src/common/facets.cpp
+++ b/src/common/facets.cpp
@@ -80,7 +80,7 @@ namespace ear {
       {16, 3, 5, 14}, {16, 17, 5, 6}, {17, 4, 6, 15}, {9, 10, 5, 6},
   };
 
-  const std::map<std::string, std::vector<Facet>> FACETS = {
+  std::map<std::string, std::vector<Facet>> FACETS = {
       {"0+5+0", FACETS_0_5_0},   {"2+5+0", FACETS_2_5_0},
       {"4+5+0", FACETS_4_5_0},   {"4+5+1", FACETS_4_5_1},
       {"3+7+0", FACETS_3_7_0},   {"4+9+0", FACETS_4_9_0},

--- a/src/common/facets.cpp
+++ b/src/common/facets.cpp
@@ -87,4 +87,8 @@ namespace ear {
       {"9+10+3", FACETS_9_10_3}, {"0+7+0", FACETS_0_7_0},
       {"4+7+0", FACETS_4_7_0},
   };
+
+  void registerFacets(const std::string &layoutName, std::vector<Facet> facets) {
+    FACETS[layoutName] = std::move(facets);
+  }
 }  // namespace ear

--- a/src/common/facets.hpp
+++ b/src/common/facets.hpp
@@ -6,5 +6,5 @@
 
 namespace ear {
   using Facet = std::set<int>;
-  extern const std::map<std::string, std::vector<Facet>> FACETS;
+  extern std::map<std::string, std::vector<Facet>> FACETS;
 }  // namespace ear

--- a/src/common/facets.hpp
+++ b/src/common/facets.hpp
@@ -1,10 +1,9 @@
 #pragma once
 #include <map>
-#include <set>
 #include <string>
 #include <vector>
+#include "ear/layout.hpp"
 
 namespace ear {
-  using Facet = std::set<int>;
   extern std::map<std::string, std::vector<Facet>> FACETS;
 }  // namespace ear

--- a/tools/create_facets_cpp.py
+++ b/tools/create_facets_cpp.py
@@ -22,7 +22,7 @@ for layout_name in layouts:
     positions_nominal = np.concatenate(
         (layout_extra.nominal_positions, virtual_positions))
     facets = _convex_hull_facets(positions_nominal)
-    print('const std::vector<Facet> FACETS_' +
+    print('std::vector<Facet> FACETS_' +
           layout_name.replace('+', '_') + ' = {')
     for facet in facets:
         print(str(facet) + ',')


### PR DESCRIPTION
This allows using custom layouts by writing the required facets before constructing the renderer.

This feels a bit wrong, because if this method is used it makes constructing the renderer non-thread-safe and dependent on things outside the constructor arguments. Some options to resolve this:
1) document this behavior
2) wrap usage of facets in a lock
3) introduce some kind of configuration mechanism used when constructing the gain calculators. I think this could be done in a backwards-compatible way, but it will have to thread through quite a lot of hierarchy.

This is in ascending order of niceness and implementations complexity. If we ever want to introduce a configuration mechanism, now is probably the best time for it.