### PR TITLE
fix codecov ignore patterns

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 ignore:
-  - "/usr/*"
-  - "examples/*"
-  - "submodules/*"
-  - "tests/*"
-  - "tools/*"
+  - "/usr"
+  - "examples"
+  - "submodules"
+  - "tests"
+  - "tools"


### PR DESCRIPTION
According to the docs, folder/* does not ignore recursively, so Eigen was showing up in the coverage reports.