### PR TITLE
replace abs with std::abs

### DIFF
--- a/src/common/geom.cpp
+++ b/src/common/geom.cpp
@@ -48,7 +48,7 @@ namespace ear {
     double min = std::numeric_limits<double>::max();
     for (int i = 1; i < vertices.rows(); ++i) {
       Eigen::Vector3d vertex = vertices.row(i).transpose() - centre;
-      double angle = abs(vertex.dot(a));
+      double angle = std::abs(vertex.dot(a));
       if (angle < min) {
         min = angle;
         b = vertex;

--- a/src/common/point_source_panner.cpp
+++ b/src/common/point_source_panner.cpp
@@ -159,8 +159,8 @@ namespace ear {
   std::vector<double> real_quadratic_roots(double a, double b, double c) {
     double eps = 1e-10;
 
-    if (abs(c) < eps) return {0.0};
-    if (abs(a) < eps) return {-c / b};
+    if (std::abs(c) < eps) return {0.0};
+    if (std::abs(a) < eps) return {-c / b};
 
     double det = b * b - 4.0 * a * c;
     if (det > eps)
@@ -294,8 +294,8 @@ namespace ear {
       if (currentLayerLayout.channels().size() != 0) {
         double azimuthRange = std::numeric_limits<double>::min();
         for (const auto& channel : currentLayerLayout.channels()) {
-          if (azimuthRange < abs(channel.polarPositionNominal().azimuth)) {
-            azimuthRange = abs(channel.polarPositionNominal().azimuth);
+          if (azimuthRange < std::abs(channel.polarPositionNominal().azimuth)) {
+            azimuthRange = std::abs(channel.polarPositionNominal().azimuth);
           }
         }
         azimuthLimit = azimuthRange + 40.0;
@@ -312,7 +312,8 @@ namespace ear {
 
       double epsilon = 1e-5;
       for (const auto& midChannel : midLayerLayout.channels()) {
-        if (abs(midChannel.polarPosition().azimuth) >= azimuthLimit - epsilon) {
+        if (std::abs(midChannel.polarPosition().azimuth) >=
+            azimuthLimit - epsilon) {
           extraChannels.push_back(Channel(
               "extra",
               PolarPosition(midChannel.polarPosition().azimuth,

--- a/src/direct_speakers/gain_calculator_direct_speakers.cpp
+++ b/src/direct_speakers/gain_calculator_direct_speakers.cpp
@@ -150,7 +150,7 @@ namespace ear {
       Channel channel = _layout.channels()[i];
       if (isLfe == _isLfe[i]) {
         if ((insideAngleRange(_azimuths(i), azMin, azMax, tol) ||
-             abs(_elevations(i)) >= 90.0 - tol) &&
+             std::abs(_elevations(i)) >= 90.0 - tol) &&
             (_elevations(i) > elMin - tol) && (_elevations(i) < elMax + tol) &&
             (_distances(i) > distMin - tol) &&
             (_distances(i) < distMax + tol)) {
@@ -213,7 +213,7 @@ namespace ear {
                    const std::pair<int, double>& b) -> bool {
                   return a.second < b.second;
                 });
-      if (abs(candidates[0].second - candidates[1].second) > tol) {
+      if (std::abs(candidates[0].second - candidates[1].second) > tol) {
         return candidates[0].first;
       }
     }

--- a/src/hoa/gain_calculator_hoa.cpp
+++ b/src/hoa/gain_calculator_hoa.cpp
@@ -29,7 +29,7 @@ namespace ear {
     for (size_t i = 0; i < metadata.orders.size(); i++) {
       if (metadata.orders[i] < 0)
         throw invalid_argument("orders must not be negative");
-      if (abs(metadata.degrees[i]) > metadata.orders[i])
+      if (std::abs(metadata.degrees[i]) > metadata.orders[i])
         throw invalid_argument(
             "magnitude of degree must not be greater than order");
     }

--- a/src/object_based/extent.cpp
+++ b/src/object_based/extent.cpp
@@ -43,7 +43,7 @@ namespace ear {
     double el = elevation(position);
 
     // points near the poles have indeterminate azimuth; assume 0
-    if (abs(el) > (90.0 - 1e-5)) {
+    if (std::abs(el) > (90.0 - 1e-5)) {
       az = 0.0;
     }
     return localCoordinateSystem(az, el);
@@ -118,8 +118,8 @@ namespace ear {
     double distance = 0.0;
 
     // for the straight lines
-    if (abs(azimuth) <= _circlePos) {
-      distance = abs(elevation) - _circleRadius;
+    if (std::abs(azimuth) <= _circlePos) {
+      distance = std::abs(elevation) - _circleRadius;
     } else {
       // distance from the closest circle centre
       size_t nearest_circle = azimuth < 0 ? 0 : 1;


### PR DESCRIPTION
This guarantees that we're using the floating point version. As far as I
can tell this doesn't change anything, but it's dependent on which math
header is included (`math.h` vs. `cmath`), which shouldn't really change the
behaviour.