### PR TITLE
Fix formatting

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,3 +1,4 @@
 BasedOnStyle: Google
 NamespaceIndentation: All
 AlignTrailingComments: false
+IncludeBlocks: Preserve

--- a/src/bs2051.cpp
+++ b/src/bs2051.cpp
@@ -1,8 +1,8 @@
 #include "ear/bs2051.hpp"
 
+#include <algorithm>
 #include "ear/helpers/assert.hpp"
 #include "ear/metadata.hpp"
-#include <algorithm>
 
 namespace ear {
 

--- a/src/dsp/block_convolver_impl.hpp
+++ b/src/dsp/block_convolver_impl.hpp
@@ -124,7 +124,7 @@ namespace ear {
         template <typename T>
         struct ZeroTrack {
           template <typename... Args>
-          ZeroTrack(Args &&... args) : data(std::forward<Args>(args)...) {
+          ZeroTrack(Args &&...args) : data(std::forward<Args>(args)...) {
             clear();
           }
           T data;


### PR DESCRIPTION
minor changes, just means we can run clang-format on all files without it recommending changes