### PR TITLE
move hull benchmark to separate test case with tag

### DIFF
--- a/tests/point_source_panner_tests.cpp
+++ b/tests/point_source_panner_tests.cpp
@@ -562,12 +562,20 @@ TEST_CASE("hull") {
           REQUIRE(facets_precomputed == facets_calculated);
         }
       }
-
-#ifdef CATCH_CONFIG_ENABLE_BENCHMARKING
-      if (layout.name() == "9+10+3") {
-        BENCHMARK("hull") { return convex_hull(positionsNominal); };
-      }
-#endif
     }
   }
 }
+
+#ifdef CATCH_CONFIG_ENABLE_BENCHMARKING
+TEST_CASE("hull_benchmark", "[.benchmark]") {
+  auto layout = getLayout("9+10+3").withoutLfe();
+
+  std::vector<Eigen::Vector3d> positionsReal, positionsNominal;
+  std::set<int> virtualVerts;
+  Eigen::MatrixXd downmix;
+  std::tie(positionsReal, positionsNominal, virtualVerts, downmix) =
+      getAugmentedLayout(layout);
+
+  BENCHMARK("hull 9+10+3") { return convex_hull(positionsNominal); };
+}
+#endif


### PR DESCRIPTION
- for some reason this was executed for each tolerance, which is messy and slow

- there's no point in running this through cmake as the output is hidden; select it with [benchmark] when running manually