### PR TITLE
Issue #58: Constructs struct with protected ctor with () rather than {}

### DIFF
--- a/src/conversion.cpp
+++ b/src/conversion.cpp
@@ -268,7 +268,7 @@ namespace ear {
 
     void toPolar(ObjectsTypeMetadata &otm) {
       otm.cartesian =
-          boost::apply_visitor(guess_cartesian_flag{}, otm.position);
+          boost::apply_visitor(guess_cartesian_flag(), otm.position);
 
       if (otm.cartesian) {
         CartesianPosition cart_pos =
@@ -290,7 +290,7 @@ namespace ear {
 
     void toCartesian(ObjectsTypeMetadata &otm) {
       otm.cartesian =
-          boost::apply_visitor(guess_cartesian_flag{}, otm.position);
+          boost::apply_visitor(guess_cartesian_flag(), otm.position);
 
       if (!otm.cartesian) {
         PolarPosition polar_pos = boost::get<PolarPosition>(otm.position);


### PR DESCRIPTION
The base class of the struct has a protected constructor so this commit uses parens instead of brackets for regular construction in both C++14 and 17, rather than aggregate construction in 17.  See the following for details.

https://stackoverflow.com/questions/56367480/should-this-code-fail-to-compile-in-c17

For issue #58 