### PR TITLE
Adds header for string for char[] + string

### DIFF
--- a/include/ear/exceptions.hpp
+++ b/include/ear/exceptions.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdexcept>
+#include <string>
 #include "export.hpp"
 
 namespace ear {


### PR DESCRIPTION
In several places in exceptions.hpp, a string literal is added to a string with the string literal (char[]) on the left side.  Without the <string> include, it may get a 'invalid operands' error.


For issue #60 