### PR TITLE
Update uses of `Eigen::all` to `Eigen::indexing::all`.

### DIFF
--- a/src/common/point_source_panner.cpp
+++ b/src/common/point_source_panner.cpp
@@ -102,9 +102,9 @@ namespace ear {
                          Eigen::MatrixXd positions)
       : RegionHandler(outputChannels, positions) {
     _order = ngonVertexOrder(positions);
-    Eigen::MatrixXd reorderedPositions = positions(_order, Eigen::all);
+    Eigen::MatrixXd reorderedPositions = positions(_order, Eigen::indexing::all);
     Eigen::MatrixXd reorderedAndShiftedPositions =
-        reorderedPositions(Eigen::Vector4i{1, 2, 3, 0}, Eigen::all);
+        reorderedPositions(Eigen::Vector4i{1, 2, 3, 0}, Eigen::indexing::all);
     _polyBasisX = _calcPolyBasis(reorderedPositions);
     _polyBasisY = _calcPolyBasis(reorderedAndShiftedPositions);
   };

--- a/tests/delay_buffer_tests.cpp
+++ b/tests/delay_buffer_tests.cpp
@@ -22,8 +22,8 @@ TEST_CASE("delay_buffer") {
   Eigen::MatrixXf output = Eigen::MatrixXf::Zero(testlen, 5);
   Eigen::MatrixXf expected_output = Eigen::MatrixXf::Zero(testlen, 5);
 
-  expected_output(Eigen::seqN(delay, testlen - delay), Eigen::all) =
-      input(Eigen::seqN(0, testlen - delay), Eigen::all);
+  expected_output(Eigen::seqN(delay, testlen - delay), Eigen::indexing::all) =
+      input(Eigen::seqN(0, testlen - delay), Eigen::indexing::all);
 
   PtrAdapter in_ptrs(5), out_ptrs(5);
 
@@ -31,8 +31,8 @@ TEST_CASE("delay_buffer") {
   int offset = 0;
   for (auto &block_size : block_sizes) {
     auto block = Eigen::seqN(offset, block_size);
-    in_ptrs.set_eigen(input(block, Eigen::all));
-    out_ptrs.set_eigen(output(block, Eigen::all));
+    in_ptrs.set_eigen(input(block, Eigen::indexing::all));
+    out_ptrs.set_eigen(output(block, Eigen::indexing::all));
     db.process(block_size, in_ptrs.ptrs(), out_ptrs.ptrs());
     offset += block_size;
   }

--- a/tests/gain_interpolator_tests.cpp
+++ b/tests/gain_interpolator_tests.cpp
@@ -210,7 +210,7 @@ TEST_CASE("vector") {
 
     process(interp_test, 0, input, tmp);
 
-    expected_output(Eigen::all, out) += tmp;
+    expected_output(Eigen::indexing::all, out) += tmp;
   };
   run_channel(0);
   run_channel(1);
@@ -242,9 +242,9 @@ TEST_CASE("matrix") {
     interp_test.interp_points.emplace_back(100, a[in][out]);
     interp_test.interp_points.emplace_back(200, b[in][out]);
 
-    process(interp_test, 0, input(Eigen::all, in), tmp);
+    process(interp_test, 0, input(Eigen::indexing::all, in), tmp);
 
-    expected_output(Eigen::all, out) += tmp;
+    expected_output(Eigen::indexing::all, out) += tmp;
   };
   run_channel(0, 0);
   run_channel(0, 1);

--- a/tests/geom_tests.cpp
+++ b/tests/geom_tests.cpp
@@ -136,9 +136,9 @@ TEST_CASE("test_order_vertices_random") {
       Eigen::VectorXi orderVec =
           Eigen::VectorXi::LinSpaced(numberOfNgons, 0, numberOfNgons);
       do {
-        unorderedNgon = orderedNgonRandomized(orderVec, Eigen::all);
+        unorderedNgon = orderedNgonRandomized(orderVec, Eigen::indexing::all);
         indices = ngonVertexOrder(unorderedNgon);
-        reorderedNgon = unorderedNgon(indices, Eigen::all);
+        reorderedNgon = unorderedNgon(indices, Eigen::indexing::all);
         REQUIRE(inSameOrder(reorderedNgon, orderedNgonRandomized));
       } while (std::next_permutation(orderVec.begin(), orderVec.end()));
     }
@@ -158,9 +158,9 @@ TEST_CASE("test_order_vertices_no_random") {
   Eigen::VectorXi orderVec = Eigen::VectorXi::LinSpaced(
       orderedNgon.rows(), 0, static_cast<int>(orderedNgon.rows()));
   do {
-    unorderedNgon = orderedNgon(orderVec, Eigen::all);
+    unorderedNgon = orderedNgon(orderVec, Eigen::indexing::all);
     indices = ngonVertexOrder(unorderedNgon);
-    reorderedNgon = unorderedNgon(indices, Eigen::all);
+    reorderedNgon = unorderedNgon(indices, Eigen::indexing::all);
     REQUIRE(inSameOrder(reorderedNgon, orderedNgon));
   } while (std::next_permutation(orderVec.begin(), orderVec.end()));
 }


### PR DESCRIPTION
  - Eigen made an API breaking change to this namespace in https://gitlab.com/libeigen/eigen/-/commit/5dac0b53c94a7b36b5aef609df73453c09ee66bb.
  - Allows the same code to build with the packaged submodel (Eigen 3.4.0) and Eigen head.