### PR TITLE
`vector_approx.hpp`: Add `#include <algorithm>` for `std::mismatch`.

### DIFF
--- a/tests/helper/vector_approx.hpp
+++ b/tests/helper/vector_approx.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <algorithm>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This helps with picky build settings. It's best to directly include the dependencies.