### PR TITLE
`layout.cpp`: Add `#include <iterator>` for `std::back_inserter`.

### DIFF
--- a/src/layout.cpp
+++ b/src/layout.cpp
@@ -1,5 +1,7 @@
 #include "ear/layout.hpp"
 
+#include <iterator>
+
 #include "common/geom.hpp"
 
 namespace ear {


### PR DESCRIPTION
  - Prefer directly including dependencies.